### PR TITLE
Option to disable argument parsing and getting original argument string/list

### DIFF
--- a/src/main/java/com/hansque/commands/CommandConfiguration.java
+++ b/src/main/java/com/hansque/commands/CommandConfiguration.java
@@ -7,16 +7,24 @@ import java.util.List;
 
 public class CommandConfiguration {
 
-    private List<Argument> arguments;
-    private String trigger;
-    private String description;
-    private List<String> aliases;
+    private final List<Argument> arguments;
+    private final String trigger;
+    private final String description;
+    private final List<String> aliases;
+    private final boolean parseArguments;
 
-    public CommandConfiguration(List<Argument> arguments, String trigger, String description, List<String> aliases) {
+    public CommandConfiguration(
+            List<Argument> arguments,
+            String trigger,
+            String description,
+            List<String> aliases,
+            boolean parseArguments
+    ) {
         this.arguments = arguments;
         this.trigger = trigger;
         this.description = description;
         this.aliases = aliases;
+        this.parseArguments = parseArguments;
     }
 
     public List<Argument> getArguments() {
@@ -35,17 +43,23 @@ public class CommandConfiguration {
         return aliases;
     }
 
+    public boolean getParseArguments() {
+        return parseArguments;
+    }
+
     public static class Builder {
         private List<Argument> arguments;
         private String trigger;
         private String description;
         private List<String> aliases;
+        private boolean parseArguments;
 
         public Builder() {
             this.arguments = new ArrayList<>();
             this.trigger = "";
             this.description = "";
             this.aliases = new ArrayList<>();
+            this.parseArguments = true;
         }
 
         public Builder addArgument(Argument argument) {
@@ -72,8 +86,14 @@ public class CommandConfiguration {
             return this;
         }
 
+        public Builder disableArgumentParsing() {
+            parseArguments = false;
+
+            return this;
+        }
+
         public CommandConfiguration build() {
-            return new CommandConfiguration(arguments, trigger, description, aliases);
+            return new CommandConfiguration(arguments, trigger, description, aliases, parseArguments);
         }
     }
 }

--- a/src/main/java/com/hansque/commands/CommandStringUtil.java
+++ b/src/main/java/com/hansque/commands/CommandStringUtil.java
@@ -11,6 +11,13 @@ import java.util.Map;
 public class CommandStringUtil {
 
     /**
+     * Private constructor for static utility class
+     */
+    private CommandStringUtil() {
+        // Intentionally left blank
+    }
+
+    /**
      * Strips a prefix from a string. The string must start with the prefix, otherwise an
      * illegal argument exception is thrown.
      *

--- a/src/main/java/com/hansque/commands/CommandStringUtil.java
+++ b/src/main/java/com/hansque/commands/CommandStringUtil.java
@@ -85,4 +85,21 @@ public class CommandStringUtil {
         // Only return the sub list starting from 1 (i.e. parts[0] = moduleString:triggerString)
         return new ArrayList<>(Arrays.asList(parts).subList(1, parts.length));
     }
+
+    /**
+     * Gets the original argument string from the command string. The command string must be in the following
+     * format: module:trigger arg1 arg2 ...
+     *
+     * @param commandString Command string in the described format
+     * @return Argument string
+     */
+    public static String getOriginalArgumentStringFromCommandString(String commandString) {
+        String[] parts = commandString.split(" ", 2);
+
+        if (parts.length <= 1) {
+            return "";
+        }
+
+        return parts[1];
+    }
 }

--- a/src/main/java/com/hansque/commands/argument/Arguments.java
+++ b/src/main/java/com/hansque/commands/argument/Arguments.java
@@ -6,12 +6,28 @@ import java.util.List;
 
 public class Arguments {
 
-    private List<String> args;
-    private CommandConfiguration configuration;
+    private final List<String> args;
+    private final String original;
+    private final CommandConfiguration configuration;
 
-    public Arguments(List<String> args, CommandConfiguration configuration) {
+    public Arguments(List<String> args, String original, CommandConfiguration configuration) {
         this.args = args;
+        this.original = original;
         this.configuration = configuration;
+    }
+
+    /**
+     * @return The argument list as provided by the user (words separated by space)
+     */
+    public List<String> getList() {
+        return args;
+    }
+
+    /**
+     * @return The argument string as provided by the user (not separated or transformed)
+     */
+    public String getOriginal() {
+        return original;
     }
 
     /**
@@ -98,8 +114,4 @@ public class Arguments {
             return value != null;
         }
     }
-
-    // arguments.get("city").string()
-    // arguments.get("height").int()
-    // arguments.get(cityArgument)
 }

--- a/src/main/java/com/hansque/core/Hansque.java
+++ b/src/main/java/com/hansque/core/Hansque.java
@@ -86,7 +86,7 @@ public class Hansque {
         @Override
         public void onMessageReceived(MessageReceivedEvent event) {
             // Get message from event
-            String message = event.getMessage().getContentRaw();
+            String message = event.getMessage().getContentRaw().trim();
 
             // Test if the message starts with the command prefix
             if (!message.startsWith(commandPrefix)) {
@@ -103,6 +103,7 @@ public class Hansque {
             String module = CommandStringUtil.getModuleFromCommandString(commandString);
             String trigger = CommandStringUtil.getTriggerFromCommandString(commandString);
             List<String> args = CommandStringUtil.getArgumentsFromCommandString(commandString);
+            String originalArgumentString = CommandStringUtil.getOriginalArgumentStringFromCommandString(commandString);
             String commandKey = module + ":" + trigger;
 
             // Check if command exists
@@ -113,9 +114,9 @@ public class Hansque {
             // Get command and create objects
             Command command = commands.get(module + ":" + trigger);
             CommandConfiguration commandConfiguration = command.getConfiguration();
-            Arguments arguments = new Arguments(args, commandConfiguration);
+            Arguments arguments = new Arguments(args, originalArgumentString, commandConfiguration);
 
-            if (!arguments.check()) {
+            if (commandConfiguration.getParseArguments() && !arguments.check()) {
                 // TODO: Inform user that the arguments provided are not valid
                 // TODO: Possible with a "usage: ..." message
                 // Temporary

--- a/src/test/java/command/CommandStringUtilTest.java
+++ b/src/test/java/command/CommandStringUtilTest.java
@@ -54,4 +54,13 @@ public class CommandStringUtilTest {
         assertEquals(expected, CommandStringUtil.getArgumentsFromCommandString("module:trigger arg1 arg2"));
         assertEquals(new ArrayList<>(), CommandStringUtil.getArgumentsFromCommandString("module:trigger"));
     }
+
+    @Test
+    void getOriginalArgumentStringFromCommandStringTest() {
+        assertEquals(
+                "arg1 arg2",
+                CommandStringUtil.getOriginalArgumentStringFromCommandString("module:trigger arg1 arg2")
+        );
+        assertEquals("", CommandStringUtil.getOriginalArgumentStringFromCommandString("module:trigger"));
+    }
 }


### PR DESCRIPTION
### What was the problem
It was not possible to get the original argument string after a command. This might be desirable in some cases when the arguments cannot be captured using the argument system (e.g. it is a sentence). 

### What have I done
Created the option in the command configuration to disable this parsing and retrieving the original list/string from the `Arguments` class. 

Usage:
```java
// When building the configuration
configuration = new CommandConfiguration.Builder()
    .disableArgumentParsing()
    [...]
    .build();

// When executing the command
public void execute(Arguments args, MessageReceivedEvent event) {
    String original = args.getOriginal();
    List<String> list = args.getList();
}
```