### PR TITLE
Added an implementation for future event listeners

### DIFF
--- a/src/main/java/com/hansque/core/Hansque.java
+++ b/src/main/java/com/hansque/core/Hansque.java
@@ -4,12 +4,15 @@ import com.hansque.commands.Command;
 import com.hansque.commands.CommandConfiguration;
 import com.hansque.commands.CommandStringUtil;
 import com.hansque.commands.argument.Arguments;
+import com.hansque.event.FutureEventListener;
 import com.hansque.modules.Module;
 import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.events.Event;
 import net.dv8tion.jda.core.events.ReadyEvent;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.core.hooks.ListenerAdapter;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -18,9 +21,14 @@ import java.util.List;
  */
 public class Hansque {
 
+    /**
+     * JDA instance
+     */
     private JDA jda;
+    /**
+     * Command prefix
+     */
     private String commandPrefix;
-    private List<Module> modules;
     /**
      * Mapping between moduleString -> module
      */
@@ -33,58 +41,101 @@ public class Hansque {
      * Mapping between moduleString:triggerString -> command
      */
     private HashMap<String, Command> commands;
+    /**
+     * List of future event listener
+     */
+    private List<FutureEventListener> futureEventListeners;
 
-    public Hansque(JDA jda, String commandPrefix, List<Module> modules) {
+    /**
+     * @param jda           JDA instance
+     * @param commandPrefix Command prefix
+     */
+    public Hansque(JDA jda, String commandPrefix) {
         this.jda = jda;
         this.commandPrefix = commandPrefix;
-        this.modules = modules;
         this.loadedModules = new HashMap<>();
         this.aliases = new HashMap<>();
         this.commands = new HashMap<>();
+        this.futureEventListeners = new ArrayList<>();
     }
 
     /**
-     * Initialises the bot, registering all enabled modules and setting up event listeners.
+     * Initialises the sub systems of the bot itself.
      */
     public void initialise() {
-        // Load all modules that are enabled
-        for (Module module : modules) {
-            if (module.isEnabled()) {
-                module.initialise();
-                registerModule(module);
-            }
-        }
-
-        // Lastly, register the event listener
         jda.addEventListener(new EventListener());
     }
 
     /**
-     * Internal function to register a module and store information about it.
+     * Registers and initialises a list of modules if the module is enabled.
      *
-     * @param module Module to register
+     * @param modules Modules to register
      */
-    private void registerModule(Module module) {
-        loadedModules.put(module.getName(), module);
+    public void registerModules(Module... modules) {
+        for (Module module : modules) {
+            if (!module.isEnabled()) {
+                continue;
+            }
 
-        // Save commands
-        for (Command command : module.getCommands()) {
-            // Initialise command
-            command.initialise();
-            CommandConfiguration configuration = command.getConfiguration();
-            String fullCommandName = module.getName() + ":" + configuration.getTrigger();
+            module.initialise();
+            loadedModules.put(module.getName(), module);
 
-            // And store for easier access
-            commands.put(fullCommandName, command);
-            for (String alias : configuration.getAliases()) {
-                aliases.put(alias, fullCommandName);
+            // Save commands
+            for (Command command : module.getCommands()) {
+                // Initialise command
+                command.initialise();
+                CommandConfiguration configuration = command.getConfiguration();
+                String fullCommandName = module.getName() + ":" + configuration.getTrigger();
+
+                // And store for easier access
+                commands.put(fullCommandName, command);
+                for (String alias : configuration.getAliases()) {
+                    aliases.put(alias, fullCommandName);
+                }
             }
         }
     }
 
+    /**
+     * Add a future event listener
+     *
+     * @param futureEventListener Future event listener
+     */
+    public void registerFutureEventListener(FutureEventListener futureEventListener) {
+        futureEventListeners.add(futureEventListener);
+    }
+
     class EventListener extends ListenerAdapter {
+
         @Override
-        public void onMessageReceived(MessageReceivedEvent event) {
+        public void onGenericEvent(Event event) {
+            for (int i = 0; i < futureEventListeners.size(); i++) {
+                FutureEventListener futureEventListener = futureEventListeners.get(i);
+
+                // Check if the event must be processed by a future event
+                if (futureEventListener.check(event)) {
+                    futureEventListener.handle(event);
+
+                    // If the event is done, remove it from the future events array
+                    if (futureEventListener.isDone()) {
+                        futureEventListeners.remove(futureEventListener);
+                        i--;
+                    }
+
+                    // Check if the event should be consumed
+                    if (futureEventListener.consumes()) {
+                        return;
+                    }
+                }
+            }
+
+            // Handle event normally
+            if (event instanceof MessageReceivedEvent) {
+                handleMessageReceived((MessageReceivedEvent) event);
+            }
+        }
+
+        private void handleMessageReceived(MessageReceivedEvent event) {
             // Get message from event
             String message = event.getMessage().getContentRaw();
 

--- a/src/main/java/com/hansque/core/Hansque.java
+++ b/src/main/java/com/hansque/core/Hansque.java
@@ -112,20 +112,20 @@ public class Hansque {
             for (int i = 0; i < futureEventListeners.size(); i++) {
                 FutureEventListener futureEventListener = futureEventListeners.get(i);
 
-                // Check if the event must be processed by a future event
+                // Check if the event must be processed by a future event listener
                 if (futureEventListener.check(event)) {
                     futureEventListener.handle(event);
 
-                    // If the event is done, remove it from the future events array
-                    if (futureEventListener.isDone()) {
-                        futureEventListeners.remove(futureEventListener);
-                        i--;
-                    }
-
-                    // Check if the event should be consumed
+                    // Check if the listener should be consumed
                     if (futureEventListener.consumes()) {
                         return;
                     }
+                }
+
+                // If the listener is done, remove it from the future event listeners array
+                if (futureEventListener.isDone()) {
+                    futureEventListeners.remove(futureEventListener);
+                    i--;
                 }
             }
 

--- a/src/main/java/com/hansque/event/FutureEventListener.java
+++ b/src/main/java/com/hansque/event/FutureEventListener.java
@@ -1,0 +1,51 @@
+package com.hansque.event;
+
+import net.dv8tion.jda.core.events.Event;
+
+/**
+ * Interface for a future event listener. A future event is an event that has not
+ * yet occurred yet, but <i>might</i> occur in the future. This interface captures
+ * the behaviour what should happen when such event occurs.
+ */
+public interface FutureEventListener {
+
+    /**
+     * Check whether the event matches the description of when this listener should
+     * handle the event. Return true if it matches and false if it does not match.
+     * <p>
+     * This check blocks the event pipeline, therefore the check must be lightweight
+     * and preferably not depend on long lasting processes.
+     *
+     * @param event Generic event
+     * @return True if the event should be handled by this listener, false otherwise
+     */
+    public boolean check(Event event);
+
+    /**
+     * This method indicates whether the event should be consumed, such that no other listener
+     * can handle this event. This holds for all future event listeners <i>and</i> all normal event
+     * listeners. Please be very aware of the risks when this returns true.
+     * <p>
+     * This method is only executed if {@code check()} returned true.
+     *
+     * @return True if the event should be consumed, false otherwise
+     */
+    public boolean consumes();
+
+    /**
+     * Indicates if the listener is done listening. A listener might capture more events.
+     * <p>
+     * This method is only executed if {@code check()} returned true.
+     *
+     * @return True if the listener is done listening, false otherwise.
+     */
+    public boolean isDone();
+
+    /**
+     * Method to handle the event. This method is only fired if {@code check()} returned false.
+     *
+     * @param event Event
+     */
+    public void handle(Event event);
+
+}

--- a/src/main/java/com/hansque/event/FutureEventListener.java
+++ b/src/main/java/com/hansque/event/FutureEventListener.java
@@ -33,9 +33,8 @@ public interface FutureEventListener {
     public boolean consumes();
 
     /**
-     * Indicates if the listener is done listening. A listener might capture more events.
-     * <p>
-     * This method is only executed if {@code check()} returned true.
+     * Indicates if the listener is done listening. A listener might capture more events
+     * or it may stop listening without having handled events (e.g. because of a timeout)
      *
      * @return True if the listener is done listening, false otherwise.
      */

--- a/src/main/java/com/hansque/event/SingleUseListener.java
+++ b/src/main/java/com/hansque/event/SingleUseListener.java
@@ -1,0 +1,51 @@
+package com.hansque.event;
+
+import net.dv8tion.jda.core.events.Event;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * Implementation of a single use listener.
+ */
+public class SingleUseListener implements FutureEventListener {
+
+    private final Predicate<Event> check;
+    private final Consumer<Event> handle;
+    private final boolean consumes;
+
+    public SingleUseListener(Predicate<Event> check, Consumer<Event> handle, boolean consumes) {
+        this.check = check;
+        this.handle = handle;
+        this.consumes = consumes;
+    }
+
+    /**
+     * Constructor such that consumes is true.
+     *
+     * @param handle Handle
+     */
+    public SingleUseListener(Predicate<Event> check, Consumer<Event> handle) {
+        this(check, handle, true);
+    }
+
+    @Override
+    public boolean check(Event event) {
+        return check.test(event);
+    }
+
+    @Override
+    public boolean consumes() {
+        return consumes;
+    }
+
+    @Override
+    public boolean isDone() {
+        return true;
+    }
+
+    @Override
+    public void handle(Event event) {
+        handle.accept(event);
+    }
+}

--- a/src/main/java/com/hansque/event/SingleUseListener.java
+++ b/src/main/java/com/hansque/event/SingleUseListener.java
@@ -14,10 +14,13 @@ public class SingleUseListener implements FutureEventListener {
     private final Consumer<Event> handle;
     private final boolean consumes;
 
+    private boolean done;
+
     public SingleUseListener(Predicate<Event> check, Consumer<Event> handle, boolean consumes) {
         this.check = check;
         this.handle = handle;
         this.consumes = consumes;
+        this.done = false;
     }
 
     /**
@@ -41,11 +44,12 @@ public class SingleUseListener implements FutureEventListener {
 
     @Override
     public boolean isDone() {
-        return true;
+        return done;
     }
 
     @Override
     public void handle(Event event) {
         handle.accept(event);
+        done = true;
     }
 }

--- a/src/main/java/com/hansque/main/Launcher.java
+++ b/src/main/java/com/hansque/main/Launcher.java
@@ -7,8 +7,6 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.JDABuilder;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
 
 public class Launcher {
 
@@ -27,14 +25,11 @@ public class Launcher {
 
         // Maybe move the hansque initialization and module registering to a different class
         String commandPrefix = botMapping.string("command_prefix");
-        Hansque hansque = new Hansque(
-                jda,
-                commandPrefix,
-                new ArrayList<>(
-                        Arrays.asList(
-                                Initialiser.getWeatherModule(yaml)
-                        )
-                )
+        Hansque hansque = new Hansque(jda, commandPrefix);
+
+        // Register modules
+        hansque.registerModules(
+                Initialiser.getWeatherModule(yaml)
         );
 
         try {


### PR DESCRIPTION
### What is this
An future event is an event that has yet to happen (or possibly never). Commands may want to listen for these future events to capture specific responses (see use cases). These event listeners can provide criteria for when they may handle the event. 

The `check()` method returns true if the event matches the criteria (for example, the event is an emoji response)

The `consumes()` method returns true if the event should be consumed by ONLY that event listener. If false, the event is passed on to all other future event listeners and all normal event listeners. 

The `isDone()` method checks whether the event listener should still listen for events. 

The `handle()` method handles the event when the `check()` returns true. 

### Use cases
(this information should have been in an issue yes)
A prompt on which people can respond by clicking the emoji responses. 